### PR TITLE
adapt to work for R 4.2.1

### DIFF
--- a/R/module-pickerGroup.R
+++ b/R/module-pickerGroup.R
@@ -247,8 +247,8 @@ pickerGroupServer <- function(input, output, session, data, vars) { # nocov star
     data$indicator <- Reduce(f = `&`, x = indicator)
 
     tmp <- aggregate(
-      formula = as.formula(paste("indicator", open_var, sep = "~")),
-      data = data,
+      list(indicator = data$indicator),
+      by = setNames(list(data[[open_var]]), open_var),
       FUN = Reduce, f = `|`
     )
 


### PR DESCRIPTION
This pickerGroup currently breaks on R 4.2.1 but works for R 4.1.3. See https://github.com/finddx/shinytestdir/issues/66

The proposed change fixes this problem and let's the pickerGroup work on new R versions